### PR TITLE
Use environment variable to control logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ The `git-lfs-server` needs some environment variables in order to run:
 - `GIT_LFS_EXPIRES_IN`: The number of seconds after which the server will expire the file object, for example `86400`.
 - `GIT_LFS_SERVER_CERT`: The path to the certificate file, for example `mine.crt`.
 - `GIT_LFS_SERVER_KEY`: The path to the key file, for example `mine.key`.
+- `GIT_LFS_AUTHENTICATE_TRACE`: Controls logging of `git-lfs-authenticate` command.
+- `GIT_LFS_SERVER_TRACE`: Controls logging of `git-lfs-server` command.
+- `GIT_LFS_AUTH_SERVICE_TRACE`: Controls logging of `auth-service`.
+- `GIT_LFS_HTTP_SERVER_TRACE`: Controls logging of the `http-server`.
 
 # Developing
 

--- a/bin/git_lfs_authenticate.dart
+++ b/bin/git_lfs_authenticate.dart
@@ -7,6 +7,9 @@ import 'package:grpc/grpc.dart';
 import 'package:logging/logging.dart';
 
 void main(List<String> args) {
+  if (Platform.environment['GIT_LFS_SERVER_TRACE'] != null) {
+    Logger.root.level = Level.ALL;
+  }
   runZonedGuarded(() async {
     await startAuthenticate(args);
   }, (Object error, StackTrace stack) async {
@@ -35,7 +38,7 @@ final _tag = 'git-lfs-authenticate';
 
 Future<int> onExit(lfs.StatusCode code) async {
   if (code == lfs.StatusCode.success) {
-    _log.info('$_tag has stopped peacefully.');
+    _log.fine('$_tag has stopped peacefully.');
   }
   await _channel?.shutdown();
   return code.index;

--- a/bin/git_lfs_authenticate.dart
+++ b/bin/git_lfs_authenticate.dart
@@ -7,8 +7,10 @@ import 'package:grpc/grpc.dart';
 import 'package:logging/logging.dart';
 
 void main(List<String> args) {
-  if (Platform.environment['GIT_LFS_SERVER_TRACE'] != null) {
+  if (Platform.environment['GIT_LFS_AUTHENTICATE_TRACE'] != null) {
     Logger.root.level = Level.ALL;
+  } else {
+    Logger.root.level = Level.OFF;
   }
   runZonedGuarded(() async {
     await startAuthenticate(args);

--- a/bin/git_lfs_server.dart
+++ b/bin/git_lfs_server.dart
@@ -11,6 +11,8 @@ import 'package:logging/logging.dart';
 Future<void> main(List<String> args) async {
   if (Platform.environment['GIT_LFS_SERVER_TRACE'] != null) {
     Logger.root.level = Level.ALL;
+  } else {
+    Logger.root.level = Level.INFO;
   }
 
   _log.info('$_tag has started!');
@@ -55,7 +57,7 @@ Future<void> main(List<String> args) async {
       authServiceStopped = true;
       isolate.removeOnExitListener(portAuthCmd.sendPort);
     } else {
-      _log.warning('Unexpected message from $_authServiceTag: $msg.');
+      _log.severe('Unexpected message from $_authServiceTag: $msg.');
     }
   });
 
@@ -100,7 +102,7 @@ Future<int> onExit(lfs.StatusCode code) async {
   if (code == lfs.StatusCode.success) {
     _log.info('$_tag has stopped peacefully.');
   } else {
-    _log.info('$_tag has been forced to stop!');
+    _log.warning('$_tag has been forced to stop!');
   }
   return code.index;
 }

--- a/bin/git_lfs_server.dart
+++ b/bin/git_lfs_server.dart
@@ -9,10 +9,8 @@ import 'package:git_lfs_server/logging.dart' show onRecordServer;
 import 'package:logging/logging.dart';
 
 Future<void> main(List<String> args) async {
-  if (args.isNotEmpty) {
-    if (args[0] == '--debug') {
-      Logger.root.level = Level.ALL;
-    }
+  if (Platform.environment['GIT_LFS_SERVER_TRACE'] != null) {
+    Logger.root.level = Level.ALL;
   }
 
   _log.info('$_tag has started!');

--- a/lib/auth/auth_service.dart
+++ b/lib/auth/auth_service.dart
@@ -17,9 +17,12 @@ final _tag = 'git-lfs-auth-service';
 
 /// auth-service must run on an isolate.
 Future<void> authService(List<dynamic> args) async {
-  if (Platform.environment['GIT_LFS_SERVER_TRACE'] != null) {
+  if (Platform.environment['GIT_LFS_AUTH_SERVICE_TRACE'] != null) {
     Logger.root.level = Level.ALL;
+  } else {
+    Logger.root.level = Level.INFO;
   }
+
   if (args.length < 3) {
     _log.severe('Missing arguments!');
     return;

--- a/lib/auth/auth_service.dart
+++ b/lib/auth/auth_service.dart
@@ -17,7 +17,9 @@ final _tag = 'git-lfs-auth-service';
 
 /// auth-service must run on an isolate.
 Future<void> authService(List<dynamic> args) async {
-  Logger.root.level = Level.ALL;
+  if (Platform.environment['GIT_LFS_SERVER_TRACE'] != null) {
+    Logger.root.level = Level.ALL;
+  }
   if (args.length < 3) {
     _log.severe('Missing arguments!');
     return;

--- a/lib/http_server/http_server.dart
+++ b/lib/http_server/http_server.dart
@@ -36,8 +36,10 @@ class GitLfsHttpServer {
 
   Future<void> start() async {
     _log = Logger(tag);
-    if (Platform.environment['GIT_LFS_SERVER_TRACE'] != null) {
+    if (Platform.environment['GIT_LFS_HTTP_SERVER_TRACE'] != null) {
       Logger.root.level = Level.ALL;
+    } else {
+      Logger.root.level = Level.INFO;
     }
     _router = shelf_router.Router()
       ..post('/objects/batch', _batchHandler)
@@ -59,10 +61,10 @@ class GitLfsHttpServer {
   }
 
   Future<void> stop() async {
-    _log.info('Stopping server');
+    _log.fine('Stopping server');
     await _channel?.shutdown();
     await _server.close();
-    _log.info('Server stopped');
+    _log.fine('Server stopped');
   }
 
   /// Return `(token, path, expiresIn)` when authentication is successful.

--- a/lib/http_server/http_server.dart
+++ b/lib/http_server/http_server.dart
@@ -36,7 +36,9 @@ class GitLfsHttpServer {
 
   Future<void> start() async {
     _log = Logger(tag);
-    Logger.root.level = Level.ALL;
+    if (Platform.environment['GIT_LFS_SERVER_TRACE'] != null) {
+      Logger.root.level = Level.ALL;
+    }
     _router = shelf_router.Router()
       ..post('/objects/batch', _batchHandler)
       ..get('/download/<[a-zA-Z0-9]{25}>/<[a-zA-Z0-9]{64}>', _downloadHandler);


### PR DESCRIPTION
Add the following environment variables to control logging:
- `GIT_LFS_AUTHENTICATE_TRACE`: Controls logging of `git-lfs-authenticate` command.
- `GIT_LFS_SERVER_TRACE`: Controls logging of `git-lfs-server` command.
- `GIT_LFS_AUTH_SERVICE_TRACE`: Controls logging of `auth-service`.
- `GIT_LFS_HTTP_SERVER_TRACE`: Controls logging of the `http-server`.
